### PR TITLE
feat!: Add region support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ resource "aws_vpc_ipam_organization_admin_account" "default" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.24.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.24.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
@@ -66,8 +66,9 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_ipam_pool"></a> [aws\_ipam\_pool](#input\_aws\_ipam\_pool) | The top level CIDR(s) available for usage on AWS | `list(string)` | n/a | yes |
-| <a name="input_pools"></a> [pools](#input\_pools) | n/a | <pre>map(object({<br>    cidr             = list(string)<br>    shared_principal = optional(list(string))<br>    tags             = optional(map(string))<br>  }))</pre> | n/a | yes |
+| <a name="input_pools"></a> [pools](#input\_pools) | n/a | <pre>map(object({<br/>    cidr             = list(string)<br/>    shared_principal = optional(list(string))<br/>    tags             = optional(map(string))<br/>  }))</pre> | n/a | yes |
 | <a name="input_ipam_description"></a> [ipam\_description](#input\_ipam\_description) | A description for the IPAM | `string` | `"Organization IPAM"` | no |
+| <a name="input_region"></a> [region](#input\_region) | The AWS region where resources will be created; if omitted the default provider region is used | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Map of tags to set on Terraform created resources | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,9 @@
+# Upgrading Notes
+
+This document captures required refactoring on your part when upgrading to a module version that contains breaking changes.
+
+## Upgrading to v1.0.0
+
+### Key Changes
+
+- This module now requires a minimum AWS provider version of 6.0 to support the `region` parameter. If you are using multiple AWS provider blocks, please read [migrating from multiple provider configurations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/enhanced-region-support#migrating-from-multiple-provider-configurations).

--- a/main.tf
+++ b/main.tf
@@ -18,28 +18,33 @@ locals {
   )
 }
 
-data "aws_region" "default" {}
+data "aws_region" "default" {
+  region = var.region
+}
 
 resource "aws_vpc_ipam" "default" {
+  region      = var.region
   description = var.ipam_description
   tags        = var.tags
 
   operating_regions {
-    region_name = data.aws_region.default.name
+    region_name = data.aws_region.default.region
   }
 }
 
 resource "aws_vpc_ipam_pool" "aws_pool" {
+  region         = var.region
   address_family = "ipv4"
   description    = "For usage on AWS"
   ipam_scope_id  = aws_vpc_ipam.default.private_default_scope_id
-  locale         = data.aws_region.default.name
+  locale         = data.aws_region.default.region
   tags           = var.tags
 }
 
 resource "aws_vpc_ipam_pool_cidr" "aws_pool_cidr" {
   for_each = toset(var.aws_ipam_pool)
 
+  region       = var.region
   cidr         = each.value
   ipam_pool_id = aws_vpc_ipam_pool.aws_pool.id
 }
@@ -47,10 +52,11 @@ resource "aws_vpc_ipam_pool_cidr" "aws_pool_cidr" {
 resource "aws_vpc_ipam_pool" "environment" {
   for_each = var.pools
 
+  region              = var.region
   address_family      = "ipv4"
   description         = each.key
   ipam_scope_id       = aws_vpc_ipam.default.private_default_scope_id
-  locale              = data.aws_region.default.name
+  locale              = data.aws_region.default.region
   source_ipam_pool_id = aws_vpc_ipam_pool.aws_pool.id
   tags                = var.tags
 }
@@ -58,6 +64,7 @@ resource "aws_vpc_ipam_pool" "environment" {
 resource "aws_vpc_ipam_pool_cidr" "environment" {
   for_each = { for pool in local.pool_cidr : "${pool.name}_${pool.cidr}" => pool }
 
+  region       = var.region
   cidr         = each.value.cidr
   ipam_pool_id = aws_vpc_ipam_pool.environment[each.value.name].id
 }
@@ -65,13 +72,15 @@ resource "aws_vpc_ipam_pool_cidr" "environment" {
 resource "aws_ram_resource_share" "default" {
   for_each = var.pools
 
-  name = "ipam-pool-${each.key}-share"
-  tags = var.tags
+  region = var.region
+  name   = "ipam-pool-${each.key}-share"
+  tags   = var.tags
 }
 
 resource "aws_ram_resource_association" "default" {
   for_each = var.pools
 
+  region             = var.region
   resource_arn       = aws_vpc_ipam_pool.environment[each.key].arn
   resource_share_arn = aws_ram_resource_share.default[each.key].arn
 }
@@ -79,6 +88,7 @@ resource "aws_ram_resource_association" "default" {
 resource "aws_ram_principal_association" "default" {
   for_each = { for pool in local.pool_principal : "${pool.name}_${pool.shared_principal}" => pool }
 
+  region             = var.region
   principal          = each.value.shared_principal
   resource_share_arn = aws_ram_resource_share.default[each.value.name].arn
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.0"
     }
   }
   required_version = ">= 1.3"

--- a/variables.tf
+++ b/variables.tf
@@ -17,8 +17,14 @@ variable "pools" {
   }))
 }
 
+variable "region" {
+  type        = string
+  default     = null
+  description = "The AWS region where resources will be created; if omitted the default provider region is used"
+}
+
 variable "tags" {
   type        = map(string)
-  description = "Map of tags to set on Terraform created resources"
   default     = {}
+  description = "Map of tags to set on Terraform created resources"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.24.0"
+      version = "~> 6.0"
     }
   }
   required_version = ">= 1.3"


### PR DESCRIPTION
⚠️ **This introduces a breaking change as it requires at least v6 of the AWS provider.** ⚠️

## :hammer_and_wrench: Summary

This pull request updates the MCAF module to support explicit region configuration and upgrades the AWS provider version. The main focus is on allowing users to specify the AWS region for all related resources, which improves multi-region compatibility and control. The AWS provider version is updated to the latest major version.

**Region configuration improvements:** 

* Added a new `region` variable in `variables.tf` to allow users to specify the AWS region for the SSM Parameters. If omitted, the default provider region is used.


## :rocket: Motivation

Adding `var.region` removes the need to instantiate multiple AWS provider instances for multi-region deployments and ensure compatibility with the latest AWS provider.
